### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/OnDemandFuelCells/OnDemandFuelCells.version
+++ b/GameData/OnDemandFuelCells/OnDemandFuelCells.version
@@ -1,6 +1,6 @@
 {
 	"NAME":"On Demand Fuel Cells",
-	"URL":"https://raw.githubusercontent.com/zer0Kerbal/ODFCr/OnDemandFuelCells.version",
+	"URL":"https://github.com/zer0Kerbal/ODFCr/raw/master/OnDemandFuelCells.version",
 	"DOWNLOAD":"https://github.com/zer0Kerbal/ODFCr/releases",
 	"CHANGE_LOG_URL": "https://raw.githubusercontent.com/zer0Kerbal/ODFCr/dev/changelog.md",
    "GITHUB":

--- a/OnDemandFuelCells.version
+++ b/OnDemandFuelCells.version
@@ -1,6 +1,6 @@
 {
 	"NAME":"On Demand Fuel Cells",
-	"URL":"https://raw.githubusercontent.com/zer0Kerbal/ODFCr/OnDemandFuelCells.version",
+	"URL":"https://github.com/zer0Kerbal/ODFCr/raw/master/OnDemandFuelCells.version",
 	"DOWNLOAD":"https://github.com/zer0Kerbal/ODFCr/releases",
 	"CHANGE_LOG_URL": "https://raw.githubusercontent.com/zer0Kerbal/ODFCr/dev/changelog.md",
    "GITHUB":


### PR DESCRIPTION
The current URL is a 404.
Now it's fixed.

Tagging @zer0Kerbal to make GitHub do its job of sending notifications.