### PR TITLE
Fixes #103

### DIFF
--- a/GameData/OnDemandFuelCells/Config/LargeCrewedLab.cfg
+++ b/GameData/OnDemandFuelCells/Config/LargeCrewedLab.cfg
@@ -8,12 +8,6 @@
 
 @PART[Large?Crewed?Lab]:NEEDS[OnDemandFuelCells]:FOR[OnDemandFuelCells]
 {
-	@cost += 50
-	@title ^= :$: <color=#6495ED> ODFC</color>:
-	@description ^= :(.)$:$0\n<#6495ED><i>ODFC installed.</i></color>:
-	@mass += 0.01
-	@tags ^= :$:  odfc demand:
-
 	!MODULE[ModuleResourceConverter] {}
 	MODULE,0
 	{

--- a/docs/LegalMumboJumbo/index.md
+++ b/docs/LegalMumboJumbo/index.md
@@ -1,5 +1,6 @@
 # LegalMumboJumbo
 
+
 ## Categories
 
 

--- a/docs/ReleaseNotes/index.md
+++ b/docs/ReleaseNotes/index.md
@@ -1,5 +1,6 @@
 # ReleaseNotes
 
+
 ## Categories
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 # 
 
+
 ## Categories
 - [LegalMumboJumbo](./LegalMumboJumbo/index.md)
 - [ReleaseNotes](./ReleaseNotes/index.md)


### PR DESCRIPTION
This pull request fixes https://github.com/zer0Kerbal/OnDemandFuelCells/issues/103

The problem is not incorrect syntax (the patches are syntactically correct!), neither a collateral effect from using `:NEEDS[foo]:FOR[foo]`, that when applied to a patch on a different directory than `foo` can cause trouble, but not this one.

The problem is data being patched twice, simple like that.

I deleted the one that I found less sound, trying to be the less intrusive possible to solve the issue at hands.